### PR TITLE
[FIX] GymScene 에서 상호작용 오브젝트 Collider 수정 (-성림)

### DIFF
--- a/Assets/Scenes/GymScene.unity
+++ b/Assets/Scenes/GymScene.unity
@@ -1569,7 +1569,7 @@ MeshCollider:
     serializedVersion: 2
     m_Bits: 0
   m_LayerOverridePriority: 0
-  m_IsTrigger: 1
+  m_IsTrigger: 0
   m_ProvidesContacts: 0
   m_Enabled: 1
   serializedVersion: 5
@@ -2619,7 +2619,7 @@ BoxCollider:
     serializedVersion: 2
     m_Bits: 0
   m_LayerOverridePriority: 0
-  m_IsTrigger: 1
+  m_IsTrigger: 0
   m_ProvidesContacts: 0
   m_Enabled: 1
   serializedVersion: 3
@@ -26434,7 +26434,7 @@ MonoBehaviour:
   <LavaLayerMask>k__BackingField:
     serializedVersion: 2
     m_Bits: 0
-  Mop: {fileID: 0}
+  Equipment: {fileID: 0}
 --- !u!4 &7688833916839294382
 Transform:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/OutdoorGame/Interact/InteractGymMinigame.cs
+++ b/Assets/Scripts/OutdoorGame/Interact/InteractGymMinigame.cs
@@ -32,9 +32,9 @@ public class InteractGymMinigame : MonoBehaviour
         _outline.OutlineWidth = 0f;
     }
 
-    private void OnTriggerStay(Collider other)
+    private void OnCollisionStay(Collision collision)
     {
-        if (other.CompareTag("Player"))
+        if (collision.collider.CompareTag("Player"))
         {
             if (!_isInteract)
             {
@@ -47,12 +47,36 @@ public class InteractGymMinigame : MonoBehaviour
         }
     }
 
-    private void OnTriggerExit(Collider other)
+    private void OnCollisionExit(Collision collision)
     {
-        if (other.CompareTag("Player"))
+        if (collision.collider.CompareTag("Player"))
         {
             _outline.OutlineWidth = 0f;
             _miniGameUI.isInterct = false;
         }
     }
+
+    //private void OnTriggerStay(Collider other)
+    //{
+    //    if (other.CompareTag("Player"))
+    //    {
+    //        if (!_isInteract)
+    //        {
+    //            if (_coroutine != null)
+    //                StopCoroutine(_coroutine);
+    //            _coroutine = StartCoroutine(BlinkOutlingCO());
+    //            _miniGameUI.isInterct = true;
+    //            _miniGameUI.selector = _miniGameSelect;
+    //        }
+    //    }
+    //}
+
+    //private void OnTriggerExit(Collider other)
+    //{
+    //    if (other.CompareTag("Player"))
+    //    {
+    //        _outline.OutlineWidth = 0f;
+    //        _miniGameUI.isInterct = false;
+    //    }
+    //}
 }

--- a/Assets/Scripts/OutdoorGame/Interact/InteractGymToOutPoint.cs
+++ b/Assets/Scripts/OutdoorGame/Interact/InteractGymToOutPoint.cs
@@ -21,7 +21,7 @@ public class InteractGymToOutPoint : MonoBehaviour, IInteractable
         _outline.OutlineWidth = 6f;
     }
 
-    public void OnCollisionStay(Collision collision)
+    private void OnCollisionStay(Collision collision)
     {
         if (collision.collider.CompareTag("Player")){
             _outline.OutlineWidth = 6f;
@@ -31,7 +31,7 @@ public class InteractGymToOutPoint : MonoBehaviour, IInteractable
         }
     }
 
-    public void OnCollisionExit(Collision collision)
+    private void OnCollisionExit(Collision collision)
     {
         if (collision.collider.CompareTag("Player"))
         {

--- a/Assets/Scripts/UI/GymScene/BackSquatMiniGameUI.cs
+++ b/Assets/Scripts/UI/GymScene/BackSquatMiniGameUI.cs
@@ -95,6 +95,7 @@ public class BackSquatMiniGameUI : MonoBehaviour
         _backSquatCamera.SetActive(false);
 
         _player.GetComponent<PlayerInput>().enabled = true;
+        _gymObject.GetComponent<Collider>().enabled = true;
 
         SoundManager.Instance.Play("OutdoorGame/DrumsAndBass", AudioType.BGM);
     }

--- a/Assets/Scripts/UI/GymScene/TreadmilMiniGameUI.cs
+++ b/Assets/Scripts/UI/GymScene/TreadmilMiniGameUI.cs
@@ -92,6 +92,7 @@ public class TreadmilMiniGameUI : MonoBehaviour
         _treadmilCamera.SetActive(false);
 
         _player.GetComponent<PlayerInput>().enabled = true;
+        _gymObject.GetComponent<Collider>().enabled = true;
 
         SoundManager.Instance.Play("OutdoorGame/DrumsAndBass", AudioType.BGM);
     }


### PR DESCRIPTION
플레이어가 상호작용 가능한 오브젝트를 뚫고 다니지 못하게 수정